### PR TITLE
Tests for complicated rules

### DIFF
--- a/app/models/magi/parent_caretaker_relative_spouse.rb
+++ b/app/models/magi/parent_caretaker_relative_spouse.rb
@@ -47,7 +47,7 @@ module MAGI
 
     rule "Caretaker Relationship – Spouse/Domestic Partner meets criteria" do
       if v("Applicant Parent Caretaker Category Indicator") == 'N' && v("Has Spouse/Domestic Partner") == 'Y' && v("Spouse/Domestic Partner").respond_to?(:outputs) && v("Spouse/Domestic Partner").outputs["Applicant Parent Caretaker Category Indicator"] == 'Y' && v("Lives With Spouse/Domestic Partner") == 'Y'
-        if v("Spouse/Domestic Partner Relationship") == :spouse || (%w(02 03).include?(c("Option Caretaker Relative Relationship")) && v("Has Spouse Domestic Partner Relationship") == :domestic_partner)
+        if v("Spouse/Domestic Partner Relationship") == :spouse || (%w(02 03).include?(c("Option Caretaker Relative Relationship")) && v("Spouse/Domestic Partner Relationship") == :domestic_partner)
           o["Applicant Parent Caretaker Category Indicator"] = 'Y'
           o["Parent Caretaker Category Determination Date"] = current_date
           o["Parent Caretaker Category Ineligibility Reason"] = 999

--- a/test/fixtures/rule_fixtures/income.rb
+++ b/test/fixtures/rule_fixtures/income.rb
@@ -6,34 +6,232 @@ class IncomeFixture < MagiFixture
     super
     @magi = 'Income'
     @test_sets = [
-      # {
-      #   test_name: "Income - Set Percentage Used - Adult Group",
-      #   inputs: {
-      #     "Application Year" => 2015,
-      #     "Applicant Adult Group Category Indicator" => "Y",
-      #     "Applicant Pregnancy Category Indicator" => "N",
-      #     "Applicant Parent Caretaker Category Indicator" => "N",
-      #     "Applicant Child Category Indicator" => "N",
-      #     "Applicant Optional Targeted Low Income Child Indicator" => "N",
-      #     "Applicant CHIP Targeted Low Income Child Indicator" => "N",
-      #     "Calculated Income" => 0,
-      #     "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
-      #     "Applicant Age" => 20
-      #   },
-      #   configs: {
-      #     "Base FPL" => 10,
-      #     "FPL Per Person" => 10,
-      #     "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
-      #     "Option CHIP Pregnancy Category" => "N",
-      #     "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
-      #     "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
-      #   },
-      #   expected_outputs: {
-      #     "Percentage for Medicaid Category Used" => 100,
-      #     "Percentage for CHIP Category Used" => 0
-      #   }
-      # },
-      # this is looking for a hash in the outputs and not a hard value.
+      # ensure that medicaid threshold is making its way down properly 
+      {
+        test_name: "Income - Set Percentage Used",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "Y",
+          "Applicant Pregnancy Category Indicator" => "N",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "N",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Calculated Income" => 0,
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 10,
+          "FPL Per Person" => 10,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "N",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "Percentage for Medicaid Category Used" => {"percentage" => "Y", "method" => "standard", "threshold" => 100},
+          "Percentage for CHIP Category Used" => {"percentage" => "Y", "method" => "standard", "threshold" => 133},
+        }
+      },
+      {
+        test_name: "Income - Set FPL Percentage",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "Y",
+          "Applicant Pregnancy Category Indicator" => "Y",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "N",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Calculated Income" => 0,
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 11770,
+          "FPL Per Person" => 4160,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "N",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "FPL" => 20090,
+          "FPL * Percentage Medicaid" => 21094.5, # not sure how the math for this works out
+          "FPL * Percentage CHIP" => 27724.2, # not sure how the math for this works out either 
+          "Category Used to Calculate Medicaid Income" => 'Adult Group Category',
+          "Category Used to Calculate CHIP Income" => 'Pregnancy Category'
+        }
+      },
+
+      # determine income eligibility rule - Medicaid
+      {
+        test_name: "Determine Medicaid Income Eligibility - Max Eligible Medicaid None",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "N",
+          "Applicant Pregnancy Category Indicator" => "N",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "N",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Calculated Income" => 0,
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 11770,
+          "FPL Per Person" => 4160,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "N",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "Applicant Income Medicaid Eligible Indicator" => "N",
+          "Income Medicaid Eligible Ineligibility Reason" => 401
+        }
+      },
+      {
+        test_name: "Determine Medicaid Income Eligibility - Calculated Income Greater Than Max Eligible",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "Y",
+          "Applicant Pregnancy Category Indicator" => "N",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "N",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Calculated Income" => 22090, # slightly higher than fpl * percentage medicaid from above
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 11770,
+          "FPL Per Person" => 4160,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "N",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "Applicant Income Medicaid Eligible Indicator" => "N",
+          "Income Medicaid Eligible Ineligibility Reason" => 402
+        }
+      },
+      {
+        test_name: "Determine Medicaid Income Eligibility - Calculated Income Lower Than Max Eligible",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "Y",
+          "Applicant Pregnancy Category Indicator" => "N",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "N",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Calculated Income" => 20000, 
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 11770,
+          "FPL Per Person" => 4160,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "N",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "Applicant Income Medicaid Eligible Indicator" => "Y",
+          "Income Medicaid Eligible Ineligibility Reason" => 999
+        }
+      },
+
+      # determine income eligibility rule - CHIP - 27724.2
+      {
+        test_name: "Determine CHIP Income Eligibility - No CHIP Eligibility",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "N",
+          "Applicant Pregnancy Category Indicator" => "N",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "N",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Calculated Income" => 20000, 
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 11770,
+          "FPL Per Person" => 4160,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "Y",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "Applicant Income CHIP Eligible Indicator" => "N",
+          "Income CHIP Eligible Ineligibility Reason" => 401
+        }
+      },
+      {
+        test_name: "Determine CHIP Income Eligibility - Calculated Income Greater than Max Eligible Income",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "Y",
+          "Applicant Pregnancy Category Indicator" => "Y",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "N",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Calculated Income" => 30000, 
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 11770,
+          "FPL Per Person" => 4160,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "Y",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "Applicant Income CHIP Eligible Indicator" => "N",
+          "Income CHIP Eligible Ineligibility Reason" => 402
+        }
+      },
+      {
+        test_name: "Determine CHIP Income Eligibility - Calculated Income Lower than Max Eligible Income",
+        inputs: {
+          "Application Year" => 2015,
+          "Applicant Adult Group Category Indicator" => "Y",
+          "Applicant Pregnancy Category Indicator" => "Y",
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Applicant Child Category Indicator" => "N",
+          "Applicant Optional Targeted Low Income Child Indicator" => "Y",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "Y",
+          "Calculated Income" => 20000, 
+          "Medicaid Household" => MedicaidHousehold.new("house", '', '', '', 3),
+          "Applicant Age" => 20
+        },
+        configs: {
+          "Base FPL" => 11770,
+          "FPL Per Person" => 4160,
+          "FPL" => { "2015" => { "Base FPL" => 11770, "FPL Per Person" => 4160 } },
+          "Option CHIP Pregnancy Category" => "Y",
+          "Medicaid Thresholds" => { "Adult Group Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 100 } },
+          "CHIP Thresholds" => { "Pregnancy Category" => { "percentage" => "Y", "method" => "standard", "threshold" => 133 } }
+        },
+        expected_outputs: {
+          "Applicant Income CHIP Eligible Indicator" => "Y",
+          "Income CHIP Eligible Ineligibility Reason" => 999
+        }
+      },
+
+
 
       {
         test_name: "Bad Info - Inputs",

--- a/test/fixtures/rule_fixtures/income.rb
+++ b/test/fixtures/rule_fixtures/income.rb
@@ -231,8 +231,6 @@ class IncomeFixture < MagiFixture
         }
       },
 
-
-
       {
         test_name: "Bad Info - Inputs",
         inputs: {
@@ -272,61 +270,3 @@ class IncomeFixture < MagiFixture
     ]
   end
 end
-
-# NOTES
-# This is very deeply confusing due to max eligible medicaid category. Punting. -CF 7/6/2015
-
-
-
-# expected_outputs: {
-#   "Percentage for Medicaid Category Used" => 0,
-#   "Percentage for CHIP Category Used" => 0,
-#   "FPL" => 0,
-#   "FPL * Percentage Medicaid" => 0,
-#   "FPL * Percentage CHIP" => 0,
-#   "Category Used to Calculate Medicaid Income" => 0,
-#   "Category Used to Calculate CHIP Income" => 0,
-#   "Applicant Income Medicaid Eligible Indicator" => 0,
-#   "Income Medicaid Eligible Ineligibility Reason" => 0,
-#   "Applicant Income CHIP Eligible Indicator" => 0,
-#   "Income CHIP Eligible Ineligibility Reason" => 0
-# }
-
-
-# config thresholds; 
-# "Medicaid Thresholds": { "Adult Group Category": { "percentage": "Y", "method": "standard", "threshold": 100 }
-#   "Parent Caretaker Category": {
-#     "percentage": "Y",
-#     "method": "standard",
-#     "threshold": 100
-#   },
-#   "Pregnancy Category": {
-#     "percentage": "Y",
-#     "method": "standard",
-#     "threshold": 100
-#   },
-#   "Child Category": {
-#     "percentage": "Y",
-#     "method": "standard",
-#     "threshold": 100
-#   },
-#   "Optional Targeted Low Income Child": {
-#     "percentage": "Y",
-#     "method": "standard",
-#     "threshold": 100
-#   }
-# },
-
-# "CHIP Thresholds": {
-# "Pregnancy Category": { "percentage": "Y", "method": "standard", "threshold": 133 },
-#   "Child Category": {
-#     "percentage": "Y",
-#     "method": "standard",
-#     "threshold": 100
-#   },
-#   "CHIP Targeted Low Income Child": {
-#     "percentage": "Y",
-#     "method": "standard",
-#     "threshold": 100
-#   }
-# }

--- a/test/fixtures/rule_fixtures/income.rb
+++ b/test/fixtures/rule_fixtures/income.rb
@@ -58,8 +58,8 @@ class IncomeFixture < MagiFixture
         },
         expected_outputs: {
           "FPL" => 20090,
-          "FPL * Percentage Medicaid" => 21094.5, # not sure how the math for this works out
-          "FPL * Percentage CHIP" => 27724.2, # not sure how the math for this works out either 
+          "FPL * Percentage Medicaid" => 21094.5, 
+          "FPL * Percentage CHIP" => 27724.2, 
           "Category Used to Calculate Medicaid Income" => 'Adult Group Category',
           "Category Used to Calculate CHIP Income" => 'Pregnancy Category'
         }

--- a/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
+++ b/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
@@ -162,7 +162,6 @@ class ParentCaretakerRelativeFixture < MagiFixture
           "Qualified Children List" => [ 'Child 1' ]
         }
       },
-
       {
         test_name: "Parent Caretaker - Set 4 - Two Kids Neither Qualifies",
         inputs: {

--- a/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
+++ b/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
@@ -5,55 +5,61 @@ class ParentCaretakerRelativeFixture < MagiFixture
   def initialize
     super
     @magi = 'ParentCaretakerRelative'
+
+    @parent = Applicant.new("Parent", '','','','')
+    @child = Applicant.new("Child", '','','','')
+    @household = Household.new('Household', [ @parent, @child ] )
+    @tax_return = TaxReturn.new(@parent, @child, '')
+
     @test_sets = [
-      # {
-      #   test_name: "Parent Caretaker - Applicant Child List is Empty",
-      #   inputs: {
-      #     "Person ID" => 1,
-      #     "Person List" => [],
-      #     "Physical Household" => [],
-      #     "Tax Returns" => [],
-      #     "Applicant Age" => 25,
-      #     "Applicant Relationships" => []
-      #   },
-      #   configs: {
-      #     "Child Age Threshold" => 19,
-      #     "Dependent Age Threshold" => 19,
-      #     "Option Dependent Student" => "N",
-      #     "Deprivation Requirement Retained" => "N",
-      #     "Option Caretaker Relative Relationship" => "00",
-      #     "State Unemployed Standard" => 100
-      #   },
-      #   expected_outputs: {
-      #     "Applicant Parent Caretaker Category Indicator" => "N",
-      #     "Parent Caretaker Category Ineligibility Reason" => 146,
-      #     "Qualified Children List" => []
-      #   }
-      # },
-      # {
-      #   test_name: "Parent Caretaker - Some Children Qualify",
-      #   inputs: {
-      #     "Person ID" => 1,
-      #     "Person List" => [],
-      #     "Physical Household" => [],
-      #     "Tax Returns" => [],
-      #     "Applicant Age" => 25,
-      #     "Applicant Relationships" => []
-      #   },
-      #   configs: {
-      #     "Child Age Threshold" => 19,
-      #     "Dependent Age Threshold" => 19,
-      #     "Option Dependent Student" => "N",
-      #     "Deprivation Requirement Retained" => "N",
-      #     "Option Caretaker Relative Relationship" => "00",
-      #     "State Unemployed Standard" => 100
-      #   },
-      #   expected_outputs: {
-      #     "Applicant Parent Caretaker Category Indicator" => "Y",
-      #     "Parent Caretaker Category Ineligibility Reason" => 999,
-      #     "Qualified Children List" => []
-      #   }
-      # }
+      {
+        test_name: "Parent Caretaker - Applicant Child List is Empty", #something in this is fucked up 
+        inputs: {
+          "Person ID" => "Parent",
+          "Person List" => @parent,
+          "Physical Household" => Household.new('Solo Household', [@parent]),
+          "Tax Returns" => [TaxReturn.new([@parent], nil,nil) ],
+          "Applicant Age" => 25,
+          "Applicant Relationships" => [Relationship.new(@parent, :self, '')]
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 19,
+          "Option Dependent Student" => "N",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Parent Caretaker Category Ineligibility Reason" => 146,
+          "Qualified Children List" => []
+        }
+      },
+      {
+        test_name: "Parent Caretaker - Some Children Qualify",
+        inputs: {
+          "Person ID" => "Person A",
+          "Person List" => [@parent, @child],
+          "Physical Household" => @household,
+          "Tax Returns" => [],
+          "Applicant Age" => 25,
+          "Applicant Relationships" => []
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 19,
+          "Option Dependent Student" => "N",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Applicant Parent Caretaker Category Indicator" => "Y",
+          "Parent Caretaker Category Ineligibility Reason" => 999,
+          "Qualified Children List" => []
+        }
+      },
 
       {
         test_name: "Bad Info - Inputs",

--- a/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
+++ b/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
@@ -6,19 +6,19 @@ class ParentCaretakerRelativeFixture < MagiFixture
     super
     @magi = 'ParentCaretakerRelative'
 
-    @parent = Applicant.new("Parent", '','','','')
-    @child = Applicant.new("Child", '','','','')
+    @parent = Applicant.new("Parent", {'Applicant Age' => 25 },'','','')
+    @child = Applicant.new("Child", {'Applicant Age' => 6 },'','','')
     @household = Household.new('Household', [ @parent, @child ] )
-    @tax_return = TaxReturn.new(@parent, @child, '')
+    @tax_return = TaxReturn.new( [@parent], [@child], {} )
 
     @test_sets = [
       {
-        test_name: "Parent Caretaker - Applicant Child List is Empty", #something in this is fucked up 
+        test_name: "Parent Caretaker - Applicant Child List is Empty", 
         inputs: {
           "Person ID" => "Parent",
           "Person List" => @parent,
           "Physical Household" => Household.new('Solo Household', [@parent]),
-          "Tax Returns" => [TaxReturn.new([@parent], nil,nil) ],
+          "Tax Returns" => [TaxReturn.new([@parent], [],nil) ],
           "Applicant Age" => 25,
           "Applicant Relationships" => [Relationship.new(@parent, :self, '')]
         },
@@ -37,14 +37,14 @@ class ParentCaretakerRelativeFixture < MagiFixture
         }
       },
       {
-        test_name: "Parent Caretaker - Some Children Qualify",
+        test_name: "Parent Caretaker - Child Qualifies",
         inputs: {
-          "Person ID" => "Person A",
+          "Person ID" => "Parent",
           "Person List" => [@parent, @child],
           "Physical Household" => @household,
-          "Tax Returns" => [],
+          "Tax Returns" => [ @tax_return ],
           "Applicant Age" => 25,
-          "Applicant Relationships" => []
+          "Applicant Relationships" => [Relationship.new(@parent, :self, ''), Relationship.new(@child, :child, '')]
         },
         configs: {
           "Child Age Threshold" => 19,
@@ -55,8 +55,8 @@ class ParentCaretakerRelativeFixture < MagiFixture
           "State Unemployed Standard" => 100
         },
         expected_outputs: {
-          "Applicant Parent Caretaker Category Indicator" => "Y",
-          "Parent Caretaker Category Ineligibility Reason" => 999,
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Parent Caretaker Category Ineligibility Reason" => 146,
           "Qualified Children List" => []
         }
       },

--- a/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
+++ b/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
@@ -6,20 +6,71 @@ class ParentCaretakerRelativeFixture < MagiFixture
     super
     @magi = 'ParentCaretakerRelative'
 
+    # set 1: One kid, qualifies
     @parent = Applicant.new("Parent", {'Applicant Age' => 25, 'Hours Worked Per Week' => 40},'','','')
     @parent.relationships = [Relationship.new(@parent, :self, ''), Relationship.new(@child, :child, '')]
     @child = Applicant.new("Child", {'Applicant Age' => 6 },'','','')
     @child.relationships = [Relationship.new(@child, :self, ''), Relationship.new(@parent, :parent, '')]
     @household = Household.new('Household', [ @parent, @child ] )
     @tax_return = TaxReturn.new( [@parent], [@child], {} )
-    @qualified_child_resp = 
+    
+    # set 2: Two kids, both qualify
+    @parent_2 = Applicant.new("Parent", {'Applicant Age' => 25, 'Hours Worked Per Week' => 40},'','','')
+    @parent_2.relationships = [Relationship.new(@parent_2, :self, ''), Relationship.new(@child_2a, :child, ''), Relationship.new(@child_2b, :child, '')]
+    @child_2a = Applicant.new("Child 1", {'Applicant Age' => 6 },'','','')
+    @child_2a.relationships = [Relationship.new(@child_2a, :self, ''), Relationship.new(@parent_2, :parent, ''), Relationship.new(@child_2b, :sibling, '')]
+    @child_2b = Applicant.new("Child 2", {'Applicant Age' => 6 },'','','')
+    @child_2b.relationships = [Relationship.new(@child_2b, :self, ''), Relationship.new(@parent_2, :parent, ''), Relationship.new(@child_2a, :sibling, '')]
+    @household_2 = Household.new('Household', [ @parent_2, @child_2a, @child_2b ] )
+    @tax_return_2 = TaxReturn.new( [@parent_2], [@child_2a, @child_2b], {} )
+
+    # set 3: Two kids, one qualifies
+    @parent_3 = Applicant.new("Parent", {'Applicant Age' => 40, 'Hours Worked Per Week' => 40},'','','')
+    @parent_3.relationships = [Relationship.new(@parent_3, :self, ''), Relationship.new(@child_3a, :child, ''), Relationship.new(@child_3b, :child, '')]
+    @child_3a = Applicant.new("Child 1", {'Applicant Age' => 6 },'','','')
+    @child_3a.relationships = [Relationship.new(@child_3a, :self, ''), Relationship.new(@parent_3, :parent, ''), Relationship.new(@child_3b, :sibling, '')]
+    @child_3b = Applicant.new("Child 2", {'Applicant Age' => 20 },'','','')
+    @child_3b.relationships = [Relationship.new(@child_3b, :self, ''), Relationship.new(@parent_3, :parent, ''), Relationship.new(@child_3a, :sibling, '')]
+    @household_3 = Household.new('Household', [ @parent_3, @child_3a, @child_3b ] )
+    @tax_return_3 = TaxReturn.new( [@parent_3], [@child_3a, @child_3b], {} )
+
+    # set 4: Two kids, neither qualify
+    @parent_4 = Applicant.new("Parent", {'Applicant Age' => 40, 'Hours Worked Per Week' => 40},'','','')
+    @parent_4.relationships = [Relationship.new(@parent_4, :self, ''), Relationship.new(@child_4a, :child, ''), Relationship.new(@child_4b, :child, '')]
+    @child_4a = Applicant.new("Child 1", {'Applicant Age' => 26 },'','','')
+    @child_4a.relationships = [Relationship.new(@child_4a, :self, ''), Relationship.new(@parent_4, :parent, ''), Relationship.new(@child_4b, :sibling, '')]
+    @child_4b = Applicant.new("Child 2", {'Applicant Age' => 20 },'','','')
+    @child_4b.relationships = [Relationship.new(@child_4b, :self, ''), Relationship.new(@parent_4, :parent, ''), Relationship.new(@child_4a, :sibling, '')]
+    @household_4 = Household.new('Household', [ @parent_4, @child_4a, @child_4b ] )
+    @tax_return_4 = TaxReturn.new( [@parent_4], [@child_4a, @child_4b], {} )
+
+    # set 5: Stepchildren, both qualify
+    @parent_5 = Applicant.new("Parent", {'Applicant Age' => 25, 'Hours Worked Per Week' => 40},'','','')
+    @parent_5.relationships = [Relationship.new(@parent_5, :self, ''), Relationship.new(@child_5a, :stepchild, ''), Relationship.new(@child_5b, :child, '')]
+    @child_5a = Applicant.new("Child 1", {'Applicant Age' => 6 },'','','')
+    @child_5a.relationships = [Relationship.new(@child_5a, :self, ''), Relationship.new(@parent_5, :parent, ''), Relationship.new(@child_5b, :sibling, '')]
+    @child_5b = Applicant.new("Child 2", {'Applicant Age' => 6 },'','','')
+    @child_5b.relationships = [Relationship.new(@child_5b, :self, ''), Relationship.new(@parent_5, :parent, ''), Relationship.new(@child_5a, :sibling, '')]
+    @household_5 = Household.new('Household', [ @parent_5, @child_5a, @child_5b ] )
+    @tax_return_5 = TaxReturn.new( [@parent_5], [@child_5a, @child_5b], {} )
+
+    # set 6: Parent is other relative instead of blood relative, neither qualify
+    @parent_6 = Applicant.new("Parent", {'Applicant Age' => 25, 'Hours Worked Per Week' => 40},'','','')
+    @parent_6.relationships = [Relationship.new(@parent_6, :self, ''), Relationship.new(@child_6a, :other, ''), Relationship.new(@child_6b, :other, '')]
+    @child_6a = Applicant.new("Child 1", {'Applicant Age' => 6 },'','','')
+    @child_6a.relationships = [Relationship.new(@child_6a, :self, ''), Relationship.new(@parent_6, :other_relative, ''), Relationship.new(@child_6b, :sibling, '')]
+    @child_6b = Applicant.new("Child 2", {'Applicant Age' => 6 },'','','')
+    @child_6b.relationships = [Relationship.new(@child_6b, :self, ''), Relationship.new(@parent_6, :other_relative, ''), Relationship.new(@child_6a, :sibling, '')]
+    @household_6 = Household.new('Household', [ @parent_6, @child_6a, @child_6b ] )
+    @tax_return_6 = TaxReturn.new( [@parent_6], [@child_6a, @child_6b], {} )
+
 
     @test_sets = [
       {
         test_name: "Parent Caretaker - Applicant Child List is Empty", 
         inputs: {
           "Person ID" => "Parent",
-          "Person List" => @parent,
+          "Person List" => [@parent],
           "Physical Household" => Household.new('Solo Household', [@parent]),
           "Tax Returns" => [TaxReturn.new([@parent], [],nil) ],
           "Applicant Age" => 25,
@@ -40,7 +91,7 @@ class ParentCaretakerRelativeFixture < MagiFixture
         }
       },
       {
-        test_name: "Parent Caretaker - Child Qualifies",
+        test_name: "Parent Caretaker - Set 1 - Child Qualifies ",
         inputs: {
           "Person ID" => "Parent",
           "Person List" => [@parent, @child],
@@ -63,7 +114,127 @@ class ParentCaretakerRelativeFixture < MagiFixture
           "Qualified Children List" => [ 'Child' ]
         }
       },
+      {
+        test_name: "Parent Caretaker - Set 2 -  Two Kids Both Qualify",
+        inputs: {
+          "Person ID" => "Parent",
+          "Person List" => [@parent_2, @child_2a, @child_2b],
+          "Physical Household" => @household_2,
+          "Tax Returns" => [ @tax_return_2 ],
+          "Applicant Age" => 25,
+          "Applicant Relationships" => [Relationship.new(@parent_2, :self, ''), Relationship.new(@child_2a, :child, ''), Relationship.new(@child_2b, :child, '')]
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 19,
+          "Option Dependent Student" => "N",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Applicant Parent Caretaker Category Indicator" => "Y",
+          "Parent Caretaker Category Ineligibility Reason" => 999,
+          "Qualified Children List" => [ 'Child 1', 'Child 2' ]
+        }
+      },
+      {
+        test_name: "Parent Caretaker - Set 3 - Two Kids One Qualifies",
+        inputs: {
+          "Person ID" => "Parent",
+          "Person List" => [@parent_3, @child_3a, @child_3b],
+          "Physical Household" => @household_3,
+          "Tax Returns" => [ @tax_return_3 ],
+          "Applicant Age" => 25,
+          "Applicant Relationships" => [Relationship.new(@parent_3, :self, ''), Relationship.new(@child_3a, :child, ''), Relationship.new(@child_3b, :child, '')]
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 19,
+          "Option Dependent Student" => "N",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Applicant Parent Caretaker Category Indicator" => "Y",
+          "Parent Caretaker Category Ineligibility Reason" => 999,
+          "Qualified Children List" => [ 'Child 1' ]
+        }
+      },
 
+      {
+        test_name: "Parent Caretaker - Set 4 - Two Kids Neither Qualifies",
+        inputs: {
+          "Person ID" => "Parent",
+          "Person List" => [@parent_4, @child_4a, @child_4b],
+          "Physical Household" => @household_4,
+          "Tax Returns" => [ @tax_return_4 ],
+          "Applicant Age" => 25,
+          "Applicant Relationships" => [Relationship.new(@parent_4, :self, ''), Relationship.new(@child_4a, :child, ''), Relationship.new(@child_4b, :child, '')]
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 19,
+          "Option Dependent Student" => "N",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Parent Caretaker Category Ineligibility Reason" => 146,
+          "Qualified Children List" => []
+        }
+      },
+      {
+        test_name: "Parent Caretaker - Set 5 - Stepchildren, Both Qualify",
+        inputs: {
+          "Person ID" => "Parent",
+          "Person List" => [@parent_5, @child_5a, @child_5b],
+          "Physical Household" => @household_5,
+          "Tax Returns" => [ @tax_return_5 ],
+          "Applicant Age" => 25,
+          "Applicant Relationships" => [Relationship.new(@parent_5, :self, ''), Relationship.new(@child_5a, :stepchild, ''), Relationship.new(@child_5b, :stepchild, '')]
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 19,
+          "Option Dependent Student" => "N",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Applicant Parent Caretaker Category Indicator" => "Y",
+          "Parent Caretaker Category Ineligibility Reason" => 999,
+          "Qualified Children List" => [ 'Child 1', 'Child 2']
+        }
+      },
+      {
+        test_name: "Parent Caretaker - Set 6 - Parent is Other Relative",
+        inputs: {
+          "Person ID" => "Parent",
+          "Person List" => [@parent_6, @child_6a, @child_6b],
+          "Physical Household" => @household_6,
+          "Tax Returns" => [ @tax_return_6 ],
+          "Applicant Age" => 25,
+          "Applicant Relationships" => [Relationship.new(@parent_6, :self, ''), Relationship.new(@child_6a, :other, ''), Relationship.new(@child_6b, :other, '')]
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 19,
+          "Option Dependent Student" => "N",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Applicant Parent Caretaker Category Indicator" => "N",
+          "Parent Caretaker Category Ineligibility Reason" => 146,
+          "Qualified Children List" => []
+        }
+      },
       {
         test_name: "Bad Info - Inputs",
         inputs: {
@@ -99,12 +270,3 @@ class ParentCaretakerRelativeFixture < MagiFixture
     ]
   end
 end
-
-
-# NOTES
-# leaving this for later because it's super complicated. -CF 7/7/2015
-
-
-# "Applicant Parent Caretaker Category Indicator" => "N",
-# "Parent Caretaker Category Ineligibility Reason" => 146,
-# "Qualified Children List" => ?

--- a/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
+++ b/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
@@ -54,13 +54,13 @@ class ParentCaretakerRelativeFixture < MagiFixture
     @household_5 = Household.new('Household', [ @parent_5, @child_5a, @child_5b ] )
     @tax_return_5 = TaxReturn.new( [@parent_5], [@child_5a, @child_5b], {} )
 
-    # set 6: Parent is other relative instead of blood relative, neither qualify
+    # set 6: Guardian is not a blood relative, neither qualify
     @parent_6 = Applicant.new("Parent", {'Applicant Age' => 25, 'Hours Worked Per Week' => 40},'','','')
     @parent_6.relationships = [Relationship.new(@parent_6, :self, ''), Relationship.new(@child_6a, :other, ''), Relationship.new(@child_6b, :other, '')]
     @child_6a = Applicant.new("Child 1", {'Applicant Age' => 6 },'','','')
-    @child_6a.relationships = [Relationship.new(@child_6a, :self, ''), Relationship.new(@parent_6, :other_relative, ''), Relationship.new(@child_6b, :sibling, '')]
+    @child_6a.relationships = [Relationship.new(@child_6a, :self, ''), Relationship.new(@parent_6, :other, ''), Relationship.new(@child_6b, :sibling, '')]
     @child_6b = Applicant.new("Child 2", {'Applicant Age' => 6 },'','','')
-    @child_6b.relationships = [Relationship.new(@child_6b, :self, ''), Relationship.new(@parent_6, :other_relative, ''), Relationship.new(@child_6a, :sibling, '')]
+    @child_6b.relationships = [Relationship.new(@child_6b, :self, ''), Relationship.new(@parent_6, :other, ''), Relationship.new(@child_6a, :sibling, '')]
     @household_6 = Household.new('Household', [ @parent_6, @child_6a, @child_6b ] )
     @tax_return_6 = TaxReturn.new( [@parent_6], [@child_6a, @child_6b], {} )
 
@@ -211,7 +211,7 @@ class ParentCaretakerRelativeFixture < MagiFixture
         }
       },
       {
-        test_name: "Parent Caretaker - Set 6 - Parent is Other Relative",
+        test_name: "Parent Caretaker - Set 6 - Parent is Not Related",
         inputs: {
           "Person ID" => "Parent",
           "Person List" => [@parent_6, @child_6a, @child_6b],

--- a/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
+++ b/test/fixtures/rule_fixtures/parent_caretaker_relative.rb
@@ -6,10 +6,13 @@ class ParentCaretakerRelativeFixture < MagiFixture
     super
     @magi = 'ParentCaretakerRelative'
 
-    @parent = Applicant.new("Parent", {'Applicant Age' => 25 },'','','')
+    @parent = Applicant.new("Parent", {'Applicant Age' => 25, 'Hours Worked Per Week' => 40},'','','')
+    @parent.relationships = [Relationship.new(@parent, :self, ''), Relationship.new(@child, :child, '')]
     @child = Applicant.new("Child", {'Applicant Age' => 6 },'','','')
+    @child.relationships = [Relationship.new(@child, :self, ''), Relationship.new(@parent, :parent, '')]
     @household = Household.new('Household', [ @parent, @child ] )
     @tax_return = TaxReturn.new( [@parent], [@child], {} )
+    @qualified_child_resp = 
 
     @test_sets = [
       {
@@ -55,9 +58,9 @@ class ParentCaretakerRelativeFixture < MagiFixture
           "State Unemployed Standard" => 100
         },
         expected_outputs: {
-          "Applicant Parent Caretaker Category Indicator" => "N",
-          "Parent Caretaker Category Ineligibility Reason" => 146,
-          "Qualified Children List" => []
+          "Applicant Parent Caretaker Category Indicator" => "Y",
+          "Parent Caretaker Category Ineligibility Reason" => 999,
+          "Qualified Children List" => [ 'Child' ]
         }
       },
 

--- a/test/fixtures/rule_fixtures/parent_caretaker_relative_spouse.rb
+++ b/test/fixtures/rule_fixtures/parent_caretaker_relative_spouse.rb
@@ -136,7 +136,7 @@ class ParentCaretakerRelativeSpouseFixture < MagiFixture
 
     ['02','03'].each do |eligible_option|
       @test_sets << {
-        test_name: "ParentCaretakerRelativeSpouse - Domestic Partner in Ineligible State Option #{eligible_option}, Meets Criteria",
+        test_name: "ParentCaretakerRelativeSpouse - Domestic Partner in Eligible State Option #{eligible_option}, Meets Criteria",
         inputs: {
           "Applicant Relationships" => [Relationship.new(@person, :self, {}), Relationship.new(@spouse, :domestic_partner, {})],
           "Physical Household" => Household.new('Household A', [@person,@spouse]),

--- a/test/fixtures/rule_fixtures/qualified_child.rb
+++ b/test/fixtures/rule_fixtures/qualified_child.rb
@@ -71,7 +71,7 @@ class QualifiedChildFixture < MagiFixture
           "Student Indicator" => "Y"
         },
         configs: {
-          "Child Age Threshold" => 18,
+          "Child Age Threshold" => 19,
           "Dependent Age Threshold" => 18,
           "Option Dependent Student" => "Y",
           "Deprivation Requirement Retained" => "N",
@@ -94,7 +94,7 @@ class QualifiedChildFixture < MagiFixture
           "Student Indicator" => "N"
         },
         configs: {
-          "Child Age Threshold" => 18,
+          "Child Age Threshold" => 19,
           "Dependent Age Threshold" => 18,
           "Option Dependent Student" => "Y",
           "Deprivation Requirement Retained" => "N",
@@ -119,7 +119,7 @@ class QualifiedChildFixture < MagiFixture
           "Student Indicator" => "Y"
         },
         configs: {
-          "Child Age Threshold" => 18,
+          "Child Age Threshold" => 19,
           "Dependent Age Threshold" => 18,
           "Option Dependent Student" => "Y",
           "Deprivation Requirement Retained" => "N",
@@ -142,7 +142,7 @@ class QualifiedChildFixture < MagiFixture
           "Student Indicator" => "Y"
         },
         configs: {
-          "Child Age Threshold" => 18,
+          "Child Age Threshold" => 19,
           "Dependent Age Threshold" => 18,
           "Option Dependent Student" => "Y",
           "Deprivation Requirement Retained" => "Y",
@@ -157,7 +157,7 @@ class QualifiedChildFixture < MagiFixture
       {
         test_name: "Dependent Deprived of Parental Support - Deprivation Req Y - Underemployed Parents",
         inputs: {
-          "Caretaker Age" => 40,
+          "Caretaker Age" => 18,
           "Child Age" => 15,
           "Child Parents" => [@parent_underemployed, @parent_underemployed_2],
           "Physical Household" => Household.new( 'Household A', [@parent_underemployed, @parent_underemployed_2, @child] ),
@@ -201,8 +201,193 @@ class QualifiedChildFixture < MagiFixture
         }
       },
 
+      # relationship rule
+      {
+        test_name: "Relationship Requirements - Caretaker Relationship 04 - Caretaker Over Threshold",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 15,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 11,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "04",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "Y",
+          "Child of Caretaker Relationship Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Relationship Requirements - Caretaker Relationship 04 - Caretaker Under Threshold",
+        inputs: {
+          "Caretaker Age" => 17,
+          "Child Age" => 4,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "04",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "N",
+          "Child of Caretaker Relationship Ineligibility Reason" => 130
+        }
+      },
+      {
+        test_name: "Relationship Requirements - Valid Relationship - Scenario 1",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 11,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "02",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "Y",
+          "Child of Caretaker Relationship Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Relationship Requirements - Valid Relationship - Scenario 2",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 11,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :former_spouse,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "01",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "Y",
+          "Child of Caretaker Relationship Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Relationship Requirements - Valid Relationship - Scenario 3",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 11,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :parents_domestic_partner,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "03",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "Y",
+          "Child of Caretaker Relationship Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Relationship Requirements - Invalid Relationship - Caretaker Relationship 00",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 11,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :parents_domestic_partner,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "N",
+          "Child of Caretaker Relationship Ineligibility Reason" => 132
+        }
+      },
+      {
+        test_name: "Relationship Requirements - Invalid Relationship - Caretaker Relationship 01",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 11,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :other,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "01",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "N",
+          "Child of Caretaker Relationship Ineligibility Reason" => 131
+        }
+      },
+      {
+        test_name: "Relationship Requirements - Invalid Relationship - Fallback",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 11,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :other,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "02",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Relationship Indicator" => "N",
+          "Child of Caretaker Relationship Ineligibility Reason" => 389
+        }
+      },
 
-
+      # fallbacks
       {
         test_name: "Bad Info - Inputs",
         inputs: {
@@ -238,35 +423,3 @@ class QualifiedChildFixture < MagiFixture
     ]
   end
 end
-
-# NOTES
-# no. -CF 7/7/2015
-
-      ### STUB THAT GETS TO THE END
-      # {
-      #   test_name: "Child Under Dependent Age",
-      #   inputs: {
-      #     "Caretaker Age" => 40,
-      #     "Child Age" => 15,
-      #     "Child Parents" => [@parent],
-      #     "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
-      #     "Relationship Type" => :parent,
-      #     "Student Indicator" => "Y"
-      #   },
-      #   configs: {
-      #     "Child Age Threshold" => 19,
-      #     "Dependent Age Threshold" => 18,
-      #     "Option Dependent Student" => "Y",
-      #     "Deprivation Requirement Retained" => "N",
-      #     "Option Caretaker Relative Relationship" => "00",
-      #     "State Unemployed Standard" => 100
-      #   },
-      #   expected_outputs: {
-      #     "Child of Caretaker Dependent Age Indicator" => "Y",
-      #     "Child of Caretaker Dependent Age Ineligibility Reason" => 999
-      #     # "Child of Caretaker Deprived Child Indicator" => "Y",
-      #     # "Child of Caretaker Deprived Child Ineligibility Reason" => 999,
-      #     # "Child of Caretaker Relationship Indicator" => "Y",
-      #     # "Child of Caretaker Relationship Ineligibility Reason" => 999
-      #   }
-      # },

--- a/test/fixtures/rule_fixtures/qualified_child.rb
+++ b/test/fixtures/rule_fixtures/qualified_child.rb
@@ -5,35 +5,39 @@ class QualifiedChildFixture < MagiFixture
   def initialize
     super
     @magi = 'QualifiedChild'
+
+    @parent = Applicant.new('Parent',{'Hours Worked Per Week' => 40 },'','','')
+    @child = Applicant.new('Child','','','','')
+
     @test_sets = [
       
-      # {
-      #   test_name: "FILL_IN_WITH_TEST_NAME",
-      #   inputs: {
-      #     "Caretaker Age" => 40,
-      #     "Child Age" => 15,
-      #     "Child Parents" => [],
-      #     "Physical Household" => Household.new('Household A', [Applicant.new('Parent','','','',''), Applicant.new('Child','','','','')] ),
-      #     "Relationship Type" => :parent,
-      #     "Student Indicator" => "Y"
-      #   },
-      #   configs: {
-      #     "Child Age Threshold" => 19,
-      #     "Dependent Age Threshold" => 18,
-      #     "Option Dependent Student" => "Y",
-      #     "Deprivation Requirement Retained" => "N",
-      #     "Option Caretaker Relative Relationship" => "N",
-      #     "State Unemployed Standard" => 100
-      #   },
-      #   expected_outputs: {
-      #     "Child of Caretaker Dependent Age Indicator" => "Y",
-      #     "Child of Caretaker Dependent Age Ineligibility Reason" => 999,
-      #     "Child of Caretaker Deprived Child Indicator" => "Y",
-      #     "Child of Caretaker Deprived Child Ineligibility Reason" => 999,
-      #     "Child of Caretaker Relationship Indicator" => "Y",
-      #     "Child of Caretaker Relationship Ineligibility Reason" => 999
-      #   }
-      # },
+      {
+        test_name: "GETS TO THE END",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 15,
+          "Child Parents" => [@parent],
+          "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Dependent Age Indicator" => "Y",
+          "Child of Caretaker Dependent Age Ineligibility Reason" => 999,
+          "Child of Caretaker Deprived Child Indicator" => "Y",
+          "Child of Caretaker Deprived Child Ineligibility Reason" => 999,
+          "Child of Caretaker Relationship Indicator" => "Y",
+          "Child of Caretaker Relationship Ineligibility Reason" => 999
+        }
+      },
 
 
       {

--- a/test/fixtures/rule_fixtures/qualified_child.rb
+++ b/test/fixtures/rule_fixtures/qualified_child.rb
@@ -7,12 +7,15 @@ class QualifiedChildFixture < MagiFixture
     @magi = 'QualifiedChild'
 
     @parent = Applicant.new('Parent',{'Hours Worked Per Week' => 40 },'','','')
+    @parent_2 = Applicant.new('Parent 2',{'Hours Worked Per Week' => 40 },'','','')
+    @parent_underemployed = Applicant.new('Parent',{'Hours Worked Per Week' => 10 },'','','')
+    @parent_underemployed_2 = Applicant.new('Parent 2',{'Hours Worked Per Week' => 10 },'','','')
     @child = Applicant.new('Child','','','','')
 
     @test_sets = [
-      
+      # dependent child age logic tests
       {
-        test_name: "GETS TO THE END",
+        test_name: "Child Under Dependent Age",
         inputs: {
           "Caretaker Age" => 40,
           "Child Age" => 15,
@@ -31,13 +34,173 @@ class QualifiedChildFixture < MagiFixture
         },
         expected_outputs: {
           "Child of Caretaker Dependent Age Indicator" => "Y",
-          "Child of Caretaker Dependent Age Ineligibility Reason" => 999,
-          "Child of Caretaker Deprived Child Indicator" => "Y",
-          "Child of Caretaker Deprived Child Ineligibility Reason" => 999,
-          "Child of Caretaker Relationship Indicator" => "Y",
-          "Child of Caretaker Relationship Ineligibility Reason" => 999
+          "Child of Caretaker Dependent Age Ineligibility Reason" => 999
         }
       },
+      {
+        test_name: "Child Over Dependent Age",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 40,
+          "Child Parents" => [@parent],
+          "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 19,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Dependent Age Indicator" => "N",
+          "Child of Caretaker Dependent Age Ineligibility Reason" => 147
+        }
+      },
+      {
+        test_name: "Child Equal to Dependent Age and a Student",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 18,
+          "Child Parents" => [@parent],
+          "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 18,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Dependent Age Indicator" => "Y",
+          "Child of Caretaker Dependent Age Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Child Equal to Dependent Age but Not a Student",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 18,
+          "Child Parents" => [@parent],
+          "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "N"
+        },
+        configs: {
+          "Child Age Threshold" => 18,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Dependent Age Indicator" => "N",
+          "Child of Caretaker Dependent Age Ineligibility Reason" => 137
+        }
+      },
+
+      # dependent deprived of parental support tests
+      {
+        test_name: "Dependent Deprived of Parental Support - Deprivation Req N",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 15,
+          "Child Parents" => [@parent],
+          "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 18,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "N",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Deprived Child Indicator" => "X",
+          "Child of Caretaker Deprived Child Ineligibility Reason" => 555
+        }
+      },
+      {
+        test_name: "Dependent Deprived of Parental Support - Deprivation Req Y - Single Parent",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 15,
+          "Child Parents" => [@parent],
+          "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 18,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Deprived Child Indicator" => "Y",
+          "Child of Caretaker Deprived Child Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Dependent Deprived of Parental Support - Deprivation Req Y - Underemployed Parents",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 15,
+          "Child Parents" => [@parent_underemployed, @parent_underemployed_2],
+          "Physical Household" => Household.new( 'Household A', [@parent_underemployed, @parent_underemployed_2, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 18,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Deprived Child Indicator" => "Y",
+          "Child of Caretaker Deprived Child Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Dependent Deprived of Parental Support - Deprivation Req Y - Fallback",
+        inputs: {
+          "Caretaker Age" => 40,
+          "Child Age" => 15,
+          "Child Parents" => [@parent, @parent_2],
+          "Physical Household" => Household.new( 'Household A', [@parent, @parent_2, @child] ),
+          "Relationship Type" => :parent,
+          "Student Indicator" => "Y"
+        },
+        configs: {
+          "Child Age Threshold" => 18,
+          "Dependent Age Threshold" => 18,
+          "Option Dependent Student" => "Y",
+          "Deprivation Requirement Retained" => "Y",
+          "Option Caretaker Relative Relationship" => "00",
+          "State Unemployed Standard" => 100
+        },
+        expected_outputs: {
+          "Child of Caretaker Deprived Child Indicator" => "N",
+          "Child of Caretaker Deprived Child Ineligibility Reason" => 129
+        }
+      },
+
 
 
       {
@@ -78,3 +241,32 @@ end
 
 # NOTES
 # no. -CF 7/7/2015
+
+      ### STUB THAT GETS TO THE END
+      # {
+      #   test_name: "Child Under Dependent Age",
+      #   inputs: {
+      #     "Caretaker Age" => 40,
+      #     "Child Age" => 15,
+      #     "Child Parents" => [@parent],
+      #     "Physical Household" => Household.new( 'Household A', [@parent, @child] ),
+      #     "Relationship Type" => :parent,
+      #     "Student Indicator" => "Y"
+      #   },
+      #   configs: {
+      #     "Child Age Threshold" => 19,
+      #     "Dependent Age Threshold" => 18,
+      #     "Option Dependent Student" => "Y",
+      #     "Deprivation Requirement Retained" => "N",
+      #     "Option Caretaker Relative Relationship" => "00",
+      #     "State Unemployed Standard" => 100
+      #   },
+      #   expected_outputs: {
+      #     "Child of Caretaker Dependent Age Indicator" => "Y",
+      #     "Child of Caretaker Dependent Age Ineligibility Reason" => 999
+      #     # "Child of Caretaker Deprived Child Indicator" => "Y",
+      #     # "Child of Caretaker Deprived Child Ineligibility Reason" => 999,
+      #     # "Child of Caretaker Relationship Indicator" => "Y",
+      #     # "Child of Caretaker Relationship Ineligibility Reason" => 999
+      #   }
+      # },

--- a/test/integration/rules/rules_test.rb
+++ b/test/integration/rules/rules_test.rb
@@ -46,8 +46,8 @@ class MagiRulesTest < ActionDispatch::IntegrationTest
             assert_equal set[:expected_outputs][out], result.output[out]
           end
 
-          # skip this test for immigration since it has so many moving parts
-          unless ["Immigration", "Income"].include? fixture 
+          # skip this test for a few fixtures with a lot of moving parts
+          unless ["Immigration", "Income", "QualifiedChild"].include? fixture 
             assert_equal set[:expected_outputs].count, result.output.keys.reject { |o| /Determination Date$/i.match o }.count
           end
         end

--- a/test/integration/rules/rules_test.rb
+++ b/test/integration/rules/rules_test.rb
@@ -42,8 +42,21 @@ class MagiRulesTest < ActionDispatch::IntegrationTest
           context = RuleContext.new set[:configs], set[:inputs], Time.now.yesterday
           result = eval "MAGI::#{fixture}.new.run context"
 
-          set[:expected_outputs].each_key do |out|
-            assert_equal set[:expected_outputs][out], result.output[out]
+          # special handler for this edge case since the fixture hits two different rulesets
+          if magi_fixture.magi == 'ParentCaretakerRelative'
+            set[:expected_outputs].select { |o| o != 'Qualified Children List' }.each_key do |out|
+              assert_equal set[:expected_outputs][out], result.output[out]
+            end
+
+            set[:expected_outputs]['Qualified Children List'].each do |child|
+              refute_nil result.output['Qualified Children List'].find { |c| c['Person ID'] == child}
+            end
+
+            assert_equal set[:expected_outputs]['Qualified Children List'].count, result.output['Qualified Children List'].count
+          else          
+            set[:expected_outputs].each_key do |out|
+              assert_equal set[:expected_outputs][out], result.output[out]
+            end
           end
 
           # skip this test for a few fixtures with a lot of moving parts


### PR DESCRIPTION
Add tests for the complicated rulesets (Income, Dependent Child Covered, Parent Caretaker Relative, Parent Caretaker Relative Spouse). 

This is all wrenching in the test directory, with one exception: I made a slight change to the app logic in the parent caretaker relative spouse magi on line 50. The logic seemed to be looking for a different key for domestic partner than what was being set in the calculated value, so it would either error out or just fail. 