### PR TITLE
Config api setup in home controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem "rails_12factor"
 # Deploy with Capistrano
 gem 'capistrano', :group => :development
 
+# for to hit mitc-configs
+gem 'httparty'
+
 group :development, :test do
   gem 'jasmine'
   gem 'spring'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,9 @@ GEM
       request_store (>= 1.0.5)
     hashie (3.4.1)
     hike (1.2.3)
+    httparty (0.13.3)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jasmine (2.3.0)
       jasmine-core (~> 2.3)
@@ -82,6 +85,7 @@ GEM
     minitest-test (1.1.0)
       minitest (~> 4.0)
     multi_json (1.11.0)
+    multi_xml (0.5.5)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
@@ -164,6 +168,7 @@ DEPENDENCIES
   faker
   font-awesome-rails
   gon
+  httparty
   jasmine
   minitest-rails (~> 1.0)
   minitest-reporters

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,8 +1,16 @@
 class HomeController < ActionController::Base
   def index
     gon.restrictStates = ENV["RESTRICT_STATES"] == "true"
-    gon.enabledStates = ENV["ENABLED_STATES"] ? ENV["ENABLED_STATES"].split(';') : []
     gon.accessToken = ENV["ACCESS_TOKENS"] ? ENV["ACCESS_TOKENS"].split(';').first : "none"
+
+    states_from_api = HTTParty.get('http://mitc-configs.herokuapp.com/states/active').parsed_response.map {|x| x['state_cd'] } if Rails.env.production? 
+    gon.enabledStates = if states_from_api
+    	states_from_api
+    elsif ENV['ENABLED_STATES']
+    	ENV['ENABLED_STATES']
+    else
+    	[]
+    end
 
     respond_to do |format|
       format.html


### PR DESCRIPTION
@curtismorales -- first pass at integrating MITC Configs into the broader api. Bulks up the home controller some and adds httparty for the api call (though we can, more messily, do this with the standard ruby libraries if you're prefer to avoid adding the dependency). 

side note: right now, the enabled states I have in mitc-configs are TN, ND, NJ, and DC. 
