### PR TITLE
Refugee residency tests

### DIFF
--- a/test/fixtures/rule_fixtures/refugee_assistance.rb
+++ b/test/fixtures/rule_fixtures/refugee_assistance.rb
@@ -6,29 +6,147 @@ class RefugeeAssistanceFixture < MagiFixture
     super
     @magi = 'RefugeeAssistance'
     @test_sets = [
-      # {
-      #   test_name: "FILL_IN_WITH_TEST_NAME",
-      #   inputs: {
-      #     "Refugee Status" => ?,
-      #     "Refugee Medical Assistance Start Date" => ?,
-      #     "Medicaid Residency Indicator" => ?,
-      #     "Calculated Income" => ?,
-      #     "FPL" => ?
-      #   },
-      #   configs: {
-      #     "State Offers Refugee Medical Assistance" => ?,
-      #     "Refugee Medical Assistance Income Requirement" => ?,
-      #     "Refugee Medical Assistance Threshold" => ?
-      #   },
-      #   expected_outputs: {
-      #     "Applicant Refugee Medical Assistance Indicator" => ?,
-      #     "Refugee Medical Assistance Determination Date" => ?,
-      #     "Refugee Medical Assistance Ineligibility Reason" => ?,
-      #     "APTC Referral Indicator" => ?,
-      #     "APTC Referral Ineligibility Reason" => ?
-      #   }
-      # }
-
+      {
+        test_name: "Not a refugee",
+        inputs: {
+          "Refugee Status" => "N",
+          "Refugee Medical Assistance Start Date" => 2.months.ago,
+          "Medicaid Residency Indicator" => "N",
+          "Calculated Income" => 1000,
+          "FPL" => 20
+        },
+        configs: {
+          "State Offers Refugee Medical Assistance" => "Y",
+          "Refugee Medical Assistance Income Requirement" => "N",
+          "Refugee Medical Assistance Threshold" => {"percentage" => "Y","method" => "standard","threshold" => 100}
+        },
+        expected_outputs: {
+          "Applicant Refugee Medical Assistance Indicator" => "X",
+          "Refugee Medical Assistance Ineligibility Reason" => 555
+        }
+      },
+      {
+        test_name: "State does not offer refugee assistance",
+        inputs: {
+          "Refugee Status" => "Y",
+          "Refugee Medical Assistance Start Date" => 2.months.ago,
+          "Medicaid Residency Indicator" => "N",
+          "Calculated Income" => 1000,
+          "FPL" => 20
+        },
+        configs: {
+          "State Offers Refugee Medical Assistance" => "N",
+          "Refugee Medical Assistance Income Requirement" => "N",
+          "Refugee Medical Assistance Threshold" => {"percentage" => "Y","method" => "standard","threshold" => 100}
+        },
+        expected_outputs: {
+          "Applicant Refugee Medical Assistance Indicator" => "X",
+          "Refugee Medical Assistance Ineligibility Reason" => 555
+        }
+      },
+      {
+        test_name: "Refugee Assistance End Date has Passed",
+        inputs: {
+          "Refugee Status" => "Y",
+          "Refugee Medical Assistance Start Date" => 2.years.ago,
+          "Medicaid Residency Indicator" => "N",
+          "Calculated Income" => 1000,
+          "FPL" => 20
+        },
+        configs: {
+          "State Offers Refugee Medical Assistance" => "Y",
+          "Refugee Medical Assistance Income Requirement" => "N",
+          "Refugee Medical Assistance Threshold" => {"percentage" => "Y","method" => "standard","threshold" => 100}
+        },
+        expected_outputs: {
+          "Applicant Refugee Medical Assistance Indicator" => "N",
+          "Refugee Medical Assistance Ineligibility Reason" => 112,
+          "APTC Referral Indicator" => "Y"
+          # "APTC Referral Ineligibility Reason" => ?
+        }
+      },
+      {
+        test_name: "Is Not Medicaid Resident",
+        inputs: {
+          "Refugee Status" => "Y",
+          "Refugee Medical Assistance Start Date" => 2.months.ago,
+          "Medicaid Residency Indicator" => "N",
+          "Calculated Income" => 1000,
+          "FPL" => 20
+        },
+        configs: {
+          "State Offers Refugee Medical Assistance" => "Y",
+          "Refugee Medical Assistance Income Requirement" => "N",
+          "Refugee Medical Assistance Threshold" => {"percentage" => "Y","method" => "standard","threshold" => 100}
+        },
+        expected_outputs: {
+          "Applicant Refugee Medical Assistance Indicator" => "N",
+          "Refugee Medical Assistance Ineligibility Reason" => 309,
+          "APTC Referral Indicator" => "Y"
+        }
+      },
+      {
+        test_name: "No Refugee Assistance Income Requirement",
+        inputs: {
+          "Refugee Status" => "Y",
+          "Refugee Medical Assistance Start Date" => 2.months.ago,
+          "Medicaid Residency Indicator" => "Y",
+          "Calculated Income" => 1000,
+          "FPL" => 20
+        },
+        configs: {
+          "State Offers Refugee Medical Assistance" => "Y",
+          "Refugee Medical Assistance Income Requirement" => "N",
+          "Refugee Medical Assistance Threshold" => {"percentage" => "Y","method" => "standard","threshold" => 100}
+        },
+        expected_outputs: {
+          "Applicant Refugee Medical Assistance Indicator" => "Y",
+          "Refugee Medical Assistance Ineligibility Reason" => 999,
+          "APTC Referral Indicator" => "N",
+          "APTC Referral Ineligibility Reason" => 407
+        }
+      },
+      {
+        test_name: "Refugee Assistance Income Requirement, Calculated Income Below Threshold",
+        inputs: {
+          "Refugee Status" => "Y",
+          "Refugee Medical Assistance Start Date" => 2.months.ago,
+          "Medicaid Residency Indicator" => "Y",
+          "Calculated Income" => 1000,
+          "FPL" => 20000
+        },
+        configs: {
+          "State Offers Refugee Medical Assistance" => "Y",
+          "Refugee Medical Assistance Income Requirement" => "Y",
+          "Refugee Medical Assistance Threshold" => {"percentage" => "Y","method" => "standard","threshold" => 100}
+        },
+        expected_outputs: {
+          "Applicant Refugee Medical Assistance Indicator" => "Y",
+          "Refugee Medical Assistance Ineligibility Reason" => 999,
+          "APTC Referral Indicator" => "N",
+          "APTC Referral Ineligibility Reason" => 407
+        }
+      },
+      {
+        test_name: "Fallback",
+        inputs: {
+          "Refugee Status" => "Y",
+          "Refugee Medical Assistance Start Date" => 2.months.ago,
+          "Medicaid Residency Indicator" => "Y",
+          "Calculated Income" => 1000,
+          "FPL" => 700
+        },
+        configs: {
+          "State Offers Refugee Medical Assistance" => "Y",
+          "Refugee Medical Assistance Income Requirement" => "Y",
+          "Refugee Medical Assistance Threshold" => {"percentage" => "Y","method" => "standard","threshold" => 100}
+        },
+        expected_outputs: {
+          "Applicant Refugee Medical Assistance Indicator" => "N",
+          "Refugee Medical Assistance Ineligibility Reason" => 373,
+          "APTC Referral Indicator" => "Y"
+        }
+      },
       {
         test_name: "Bad Info - Inputs",
         inputs: {

--- a/test/fixtures/rule_fixtures/residency.rb
+++ b/test/fixtures/rule_fixtures/residency.rb
@@ -6,29 +6,69 @@ class ResidencyFixture < MagiFixture
     super
     @magi = 'Residency'
     @test_sets = [
-      # {
-      #   test_name: "FILL_IN_WITH_TEST_NAME",
-      #   inputs: {
-      #     "Lives In State" => "Y",
-      #     "No Fixed Address" => "N",
-      #     "Temporarily Out of State" => "N",
-      #     "Medicaid Household" => "N",
-      #     "Claimed as Dependent by Person Not on Application" => "N",
-      #     "Claimer Is Out of State" => "N",
-      #     "Student Indicator" => "N",
-      #     "Person ID" => "N",
-      #     "Tax Returns" => []
-      #   },
-      #   configs: {
-      #     "Option Deny Residency to Temporary Resident Students" => ?
-      #   },
-      #   expected_outputs: {
-      #     "Medicaid Residency Indicator" => ?,
-      #     "Medicaid Residency Indicator Determination Date" => ?,
-      #     "Medicaid Residency Indicator Ineligibility Reason" => ?
-      #   }
-      # }
-
+      {
+        test_name: "Lives in State, Denies Residency to Students",
+        inputs: {
+          "Lives In State" => "Y",
+          "No Fixed Address" => "N",
+          "Temporarily Out of State" => "N",
+          "Medicaid Household" => MedicaidHousehold.new('something', [Person.new('guy','','')], '','',1),
+          "Claimed as Dependent by Person Not on Application" => "Y",
+          "Claimer Is Out of State" => "Y",
+          "Student Indicator" => "Y",
+          "Person ID" => "guy",
+          "Tax Returns" => []
+        },
+        configs: {
+          "Option Deny Residency to Temporary Resident Students" => "Y"
+        },
+        expected_outputs: {
+          "Medicaid Residency Indicator" => "N",
+          "Medicaid Residency Indicator Ineligibility Reason" => 403
+        }
+      },
+      {
+        test_name: "Lives in State, Cool With Students",
+        inputs: {
+          "Lives In State" => "Y",
+          "No Fixed Address" => "N",
+          "Temporarily Out of State" => "N",
+          "Medicaid Household" => MedicaidHousehold.new('something', [Person.new('guy','','')], '','',1),
+          "Claimed as Dependent by Person Not on Application" => "Y",
+          "Claimer Is Out of State" => "Y",
+          "Student Indicator" => "Y",
+          "Person ID" => "guy",
+          "Tax Returns" => []
+        },
+        configs: {
+          "Option Deny Residency to Temporary Resident Students" => "N"
+        },
+        expected_outputs: {
+          "Medicaid Residency Indicator" => "Y",
+          "Medicaid Residency Indicator Ineligibility Reason" => 999
+        }
+      },
+      {
+        test_name: "Does Not Live in State",
+        inputs: {
+          "Lives In State" => "N",
+          "No Fixed Address" => "N",
+          "Temporarily Out of State" => "N",
+          "Medicaid Household" => MedicaidHousehold.new('something', [Person.new('guy','','')], '','',1),
+          "Claimed as Dependent by Person Not on Application" => "Y",
+          "Claimer Is Out of State" => "Y",
+          "Student Indicator" => "Y",
+          "Person ID" => "guy",
+          "Tax Returns" => []
+        },
+        configs: {
+          "Option Deny Residency to Temporary Resident Students" => "N"
+        },
+        expected_outputs: {
+          "Medicaid Residency Indicator" => "N",
+          "Medicaid Residency Indicator Ineligibility Reason" => 404
+        }
+      },
       {
         test_name: "Bad Info - Inputs",
         inputs: {


### PR DESCRIPTION
Add tests for residency and refugee assistance, which should be all the magi rules. 