### PR TITLE
WIP - Ruby 2.3.3 and Rails 3.2.22.5 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.3.1
+- 2.3.3
 sudo: false
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.0.0
+- 2.3.1
 sudo: false
 notifications:
   slack:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'http://rubygems.org'
-# ruby '2.3.1'
-ruby '2.0.0'
+ruby '2.3.1'
 
-# gem 'rails', '3.2.12'
 gem 'rails', '3.2.22.5'
 
 # Bundle edge Rails instead:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'http://rubygems.org'
-ruby '2.0.0'
+ruby '2.3.1'
 
 gem 'rails', '3.2.12'
 
@@ -49,3 +49,4 @@ end
 
 # travis
 gem 'rake', group: :test
+gem 'test-unit'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'http://rubygems.org'
-ruby '2.3.1'
+ruby '2.3.3'
 
 gem 'rails', '3.2.22.5'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'http://rubygems.org'
-ruby '2.3.1'
+# ruby '2.3.1'
+ruby '2.0.0'
 
-gem 'rails', '3.2.12'
+# gem 'rails', '3.2.12'
+gem 'rails', '3.2.22.5'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 2.0.0p648
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.13.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     pg (0.18.1)
     phantomjs (1.9.8.0)
     polyglot (0.3.5)
-    power_assert (0.2.6)
+    power_assert (0.3.1)
     powerbar (1.0.12)
       ansi (~> 1.5.0)
       hashie (>= 1.1.0)
@@ -144,7 +144,7 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    test-unit (3.1.5)
+    test-unit (3.2.2)
       power_assert
     thor (0.19.1)
     tilt (1.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.5
+   1.14.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.13.0)
-    rake (11.3.0)
+    rake (12.0.0)
     rdoc (3.12.2)
       json (~> 1.4)
     request_store (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    actionmailer (3.2.12)
-      actionpack (= 3.2.12)
-      mail (~> 2.4.4)
-    actionpack (3.2.12)
-      activemodel (= 3.2.12)
-      activesupport (= 3.2.12)
+    actionmailer (3.2.22.5)
+      actionpack (= 3.2.22.5)
+      mail (~> 2.5.4)
+    actionpack (3.2.22.5)
+      activemodel (= 3.2.22.5)
+      activesupport (= 3.2.22.5)
       builder (~> 3.0.0)
       erubis (~> 2.7.0)
       journey (~> 1.0.4)
@@ -16,21 +16,21 @@ GEM
       sprockets (~> 2.2.1)
     active_model_serializers (0.9.3)
       activemodel (>= 3.2)
-    activemodel (3.2.12)
-      activesupport (= 3.2.12)
+    activemodel (3.2.22.5)
+      activesupport (= 3.2.22.5)
       builder (~> 3.0.0)
-    activerecord (3.2.12)
-      activemodel (= 3.2.12)
-      activesupport (= 3.2.12)
+    activerecord (3.2.22.5)
+      activemodel (= 3.2.22.5)
+      activesupport (= 3.2.22.5)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
     activerecord-nulldb-adapter (0.3.1)
       activerecord (>= 2.0.0)
-    activeresource (3.2.12)
-      activemodel (= 3.2.12)
-      activesupport (= 3.2.12)
-    activesupport (3.2.12)
-      i18n (~> 0.6)
+    activeresource (3.2.22.5)
+      activemodel (= 3.2.22.5)
+      activesupport (= 3.2.22.5)
+    activesupport (3.2.22.5)
+      i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     ansi (1.5.0)
     arel (3.0.3)
@@ -64,10 +64,9 @@ GEM
       rake
     jasmine-core (2.3.3)
     journey (1.0.4)
-    json (1.8.2)
+    json (1.8.3)
     kgio (2.9.3)
-    mail (2.4.4)
-      i18n (>= 0.4.0)
+    mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.25.1)
@@ -84,7 +83,7 @@ GEM
       powerbar
     minitest-test (1.1.0)
       minitest (~> 4.0)
-    multi_json (1.11.0)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -99,21 +98,21 @@ GEM
     powerbar (1.0.12)
       ansi (~> 1.5.0)
       hashie (>= 1.1.0)
-    rack (1.4.5)
-    rack-cache (1.2)
+    rack (1.4.7)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (3.2.12)
-      actionmailer (= 3.2.12)
-      actionpack (= 3.2.12)
-      activerecord (= 3.2.12)
-      activeresource (= 3.2.12)
-      activesupport (= 3.2.12)
+    rails (3.2.22.5)
+      actionmailer (= 3.2.22.5)
+      actionpack (= 3.2.22.5)
+      activerecord (= 3.2.22.5)
+      activeresource (= 3.2.22.5)
+      activesupport (= 3.2.22.5)
       bundler (~> 1.0)
-      railties (= 3.2.12)
+      railties (= 3.2.22.5)
     rails-api (0.4.0)
       actionpack (>= 3.2.11)
       railties (>= 3.2.11)
@@ -122,15 +121,15 @@ GEM
       rails_stdout_logging
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.3)
-    railties (3.2.12)
-      actionpack (= 3.2.12)
-      activesupport (= 3.2.12)
+    railties (3.2.22.5)
+      actionpack (= 3.2.22.5)
+      activesupport (= 3.2.22.5)
       rack-ssl (~> 1.3.2)
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.13.0)
-    rake (10.4.2)
+    rake (11.3.0)
     rdoc (3.12.2)
       json (~> 1.4)
     request_store (1.1.0)
@@ -152,7 +151,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.44)
+    tzinfo (0.3.52)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -178,7 +177,7 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri
   pg
-  rails (= 3.2.12)
+  rails (= 3.2.22.5)
   rails-api
   rails_12factor
   rake
@@ -189,7 +188,7 @@ DEPENDENCIES
   unicorn
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.0.0p648
 
 BUNDLED WITH
-   1.13.2
+   1.13.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     pg (0.18.1)
     phantomjs (1.9.8.0)
     polyglot (0.3.5)
+    power_assert (0.2.6)
     powerbar (1.0.12)
       ansi (~> 1.5.0)
       hashie (>= 1.1.0)
@@ -144,6 +145,8 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    test-unit (3.1.5)
+      power_assert
     thor (0.19.1)
     tilt (1.4.1)
     treetop (1.4.15)
@@ -181,5 +184,12 @@ DEPENDENCIES
   rake
   spring
   sqlite3
+  test-unit
   uglifier
   unicorn
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.13.2

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@
 ActiveRecord::Schema.define(:version => 0) do
 
   create_table "schema_info", :id => false, :force => true do |t|
-  	t.integer 'dummy'
+  	t.integer 'version'
   end
 
 end


### PR DESCRIPTION
Upgrades ruby version to <strike>2.3.1</strike> 2.3.3 and rails version to the most recent version of 3.2, and makes slight tweaks to get everything to cook again. 