### PR TITLE
Add new FPL info for 2017

### DIFF
--- a/config/state_config.json
+++ b/config/state_config.json
@@ -28,7 +28,7 @@
       },
       "2017": {
         "Base FPL": 12060,
-        "FPL Per Person": 4180,
+        "FPL Per Person": 4180
       }
     },
 

--- a/config/state_config.json
+++ b/config/state_config.json
@@ -29,14 +29,6 @@
       "2017": {
         "Base FPL": 12060,
         "FPL Per Person": 4180,
-        "Alaska": {
-          "Base FPL": 15060,
-          "FPL Per Person": 5230
-        },
-        "Hawaii": {
-          "Base FPL": 13860,
-          "FPL Per Person": 4810 
-        }        
       }
     },
 
@@ -242,6 +234,10 @@
           47010
         ],
         "FPL Per Extra Person": 4780
+      },
+      "2017": {
+        "Base FPL": 13860,
+        "FPL Per Person": 4810
       }
     }
   },
@@ -774,6 +770,10 @@
           51120
         ],
         "FPL Per Extra Person": 5200
+      },
+      "2017": {
+        "Base FPL": 15060,
+        "FPL Per Person": 5230
       }
     },
 

--- a/config/state_config.json
+++ b/config/state_config.json
@@ -25,6 +25,18 @@
           40890
         ],
         "FPL Per Extra Person": 4160
+      },
+      "2017": {
+        "Base FPL": 12060,
+        "FPL Per Person": 4180,
+        "Alaska": {
+          "Base FPL": 15060,
+          "FPL Per Person": 5230
+        },
+        "Hawaii": {
+          "Base FPL": 13860,
+          "FPL Per Person": 4810 
+        }        
       }
     },
 

--- a/doc/FPL_INFO.md
+++ b/doc/FPL_INFO.md
@@ -1,0 +1,1 @@
+FPL information is sourced from [HHS ASPE](https://aspe.hhs.gov/poverty-guidelines).


### PR DESCRIPTION
The new FPL information has been released by HHS ASPE at https://aspe.hhs.gov/poverty-guidelines , so this pull request does two things:

a) incorporates in 2017 FPL levels for the lower 48, plus Alaska and Hawaii in their respective states, which I believe take effect April 1;

b) Adds a note in the doc about where the ASPE guidelines are posted, for later reference when it comes up next year.

@curtismorales for your review and approval