### PR TITLE
Previously Denied should override eligibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	docker-compose run --rm -e "RAILS_ENV=test" web rake test

--- a/app/models/application_processor.rb
+++ b/app/models/application_processor.rb
@@ -35,11 +35,11 @@ module ApplicationProcessor
       MAGI::OptionalUnbornChild,
       MAGI::PublicEmployeesBenefits,
       MAGI::CHIPWaitingPeriod,
+      MAGI::PreviouslyDenied,
       MAGI::CHIPEligibility,
       MAGI::MedicaidEligibility,
       MAGI::EmergencyMedicaid,
-      MAGI::RefugeeAssistance,
-      MAGI::PreviouslyDenied
+      MAGI::RefugeeAssistance
     ].map{|ruleset_class| ruleset_class.new()}
 
     for ruleset in rulesets

--- a/app/models/application_responder.rb
+++ b/app/models/application_responder.rb
@@ -36,6 +36,9 @@ module ApplicationResponder
         if app.outputs["Applicant Dependent Child Covered Indicator"] == 'N'
           ineligibility_reasons << "Applicant has a dependent child who does not have coverage and is not included on the application"
         end
+        if app.outputs["Previously Denied"]
+          ineligibility_reasons << "Overriden to ineligible because applicant was previously denied"
+        end
         app_json["Ineligibility Reason"] = ineligibility_reasons
         app_json["Non-MAGI Referral"] = app.outputs["Applicant Medicaid Non-MAGI Referral Indicator"]
       end
@@ -65,6 +68,9 @@ module ApplicationResponder
         end
         if app.applicant_attributes["Incarceration Status"] == 'Y'
           ineligibility_reasons << "Applicant is incarcerated"
+        end
+        if app.outputs["Previously Denied"]
+          ineligibility_reasons << "Overriden to ineligible because applicant was previously denied"
         end
         app_json["CHIP Ineligibility Reason"] = ineligibility_reasons
       end
@@ -106,7 +112,7 @@ module ApplicationResponder
         app_json["Determinations"]["APTC Referral"] = det_json
       end
 
-      if app.outputs["Previously Denied"]
+      if app.outputs["Previously Denied"] == 'Y' || app.outputs["Previously Denied"] == 'N'
         det_json = {}
         det_json["Indicator"] = app.outputs["Previously Denied"]
         if app.outputs["Previously Denied"] == 'N'

--- a/app/models/magi/chip_eligibility.rb
+++ b/app/models/magi/chip_eligibility.rb
@@ -8,19 +8,25 @@ module MAGI
     input "Applicant State Health Benefits CHIP Indicator", "State Health Benefits Through Public Employees rule", "Char(1)", %w(Y N X)
     input "Applicant CHIP Waiting Period Satisfied Indicator", "CHIP Waiting Period rule", "Char(1)", %w(Y N X)
     input "Applicant CHIP Targeted Low Income Child Indicator", "CHIP Targeted Low-Income Children rule", "Char(1)", %w(Y N X)
+    input "Previously Denied", "Char(1)", %w(Y N)
 
     # Outputs
     determination "CHIP", %w(Y N), %w(999 107 405)
     output "APTC Referral Indicator", "Char(1)", %w(Y N)
 
     rule "Determine final CHIP eligibility" do
-      if v("Incarceration Status") == 'Y'
+      # Note: we use input directly here because we want to allow that Previously Denied might be unset
+      if @input["Previously Denied"] == 'Y'
+        o["Applicant CHIP Indicator"] = 'N'
+        o["CHIP Determination Date"] = current_date
+        o["CHIP Ineligibility Reason"] = 123
+      elsif v("Incarceration Status") == 'Y'
         o["Applicant CHIP Indicator"] = 'N'
         o["CHIP Determination Date"] = current_date
         o["CHIP Ineligibility Reason"] = 405
-      elsif (v("Applicant CHIP Prelim Indicator") == 'Y' && 
-          %w(Y X).include?(v("Applicant State Health Benefits CHIP Indicator")) && 
-          %w(Y X).include?(v("Applicant CHIP Waiting Period Satisfied Indicator"))) || 
+      elsif (v("Applicant CHIP Prelim Indicator") == 'Y' &&
+          %w(Y X).include?(v("Applicant State Health Benefits CHIP Indicator")) &&
+          %w(Y X).include?(v("Applicant CHIP Waiting Period Satisfied Indicator"))) ||
         v("Applicant Unborn Child Indicator") == 'Y'
         determination_y "CHIP"
       else

--- a/app/models/magi/medicaid_eligibility.rb
+++ b/app/models/magi/medicaid_eligibility.rb
@@ -3,14 +3,20 @@
 module MAGI
   class MedicaidEligibility < Ruleset
     input "Applicant Medicaid Prelim Indicator", "From Determine Preliminary Medicaid & CHIP Eligibility Rule", "Char(1)", %w(Y N)
+    input "Previously Denied", "Char(1)", %w(Y N)
 
-    # Outputs 
+    # Outputs
     determination "Medicaid", %w(Y N), %w(999 128 106)
     output "APTC Referral Indicator", "Char(1)", %w(Y N)
     output "APTC Referral Ineligibility Reason", "Char(3)", %w(406)
 
     rule "Determine final Medicaid eligibility" do
-      if v("Applicant Medicaid Prelim Indicator") == 'Y'
+      # Note: we use input directly here because we want to allow that Previously Denied might be unset
+      if @input["Previously Denied"] == 'Y'
+        o["Applicant Medicaid Indicator"] = 'N'
+        o["Medicaid Determination Date"] = current_date
+        o["Medicaid Ineligibility Reason"] = 123
+      elsif v("Applicant Medicaid Prelim Indicator") == 'Y'
         determination_y "Medicaid"
 
         o["APTC Referral Indicator"] = 'N'

--- a/test/fixtures/rule_fixtures/chip_eligibility.rb
+++ b/test/fixtures/rule_fixtures/chip_eligibility.rb
@@ -32,7 +32,7 @@ class CHIPEligibilityFixture < MagiFixture
           "Applicant Unborn Child Indicator" => "N",
           "Applicant State Health Benefits CHIP Indicator" => "Y",
           "Applicant CHIP Waiting Period Satisfied Indicator" => "X",
-          "Applicant CHIP Targeted Low Income Child Indicator" => "N" 
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N"
         },
         configs: {
           # none
@@ -50,7 +50,7 @@ class CHIPEligibilityFixture < MagiFixture
           "Applicant Unborn Child Indicator" => "Y",
           "Applicant State Health Benefits CHIP Indicator" => "N",
           "Applicant CHIP Waiting Period Satisfied Indicator" => "X",
-          "Applicant CHIP Targeted Low Income Child Indicator" => "N" 
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N"
         },
         configs: {
           # none
@@ -59,7 +59,7 @@ class CHIPEligibilityFixture < MagiFixture
           "Applicant CHIP Indicator" => "Y",
           "CHIP Ineligibility Reason" => 999,
         }
-      }, 
+      },
       {
         test_name: "Fallback Determination - All N",
         inputs: {
@@ -68,7 +68,7 @@ class CHIPEligibilityFixture < MagiFixture
           "Applicant Unborn Child Indicator" => "N",
           "Applicant State Health Benefits CHIP Indicator" => "N",
           "Applicant CHIP Waiting Period Satisfied Indicator" => "N",
-          "Applicant CHIP Targeted Low Income Child Indicator" => "N" 
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N"
         },
         configs: {
           # none
@@ -87,7 +87,7 @@ class CHIPEligibilityFixture < MagiFixture
           "Applicant Unborn Child Indicator" => "N",
           "Applicant State Health Benefits CHIP Indicator" => "N",
           "Applicant CHIP Waiting Period Satisfied Indicator" => "N",
-          "Applicant CHIP Targeted Low Income Child Indicator" => "N" 
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N"
         },
         configs: {
           # none
@@ -101,12 +101,50 @@ class CHIPEligibilityFixture < MagiFixture
       {
         test_name: "Bad Info - Inputs",
         inputs: {
-          "Applicant CHIP Targeted Low Income Child Indicator" => "N" 
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N"
         },
         configs: {
           # none
         },
         expected_outputs: {
+        }
+      },
+      {
+        test_name: "Would pass... but Previously Denied",
+        inputs: {
+          "Incarceration Status" => "N",
+          "Applicant CHIP Prelim Indicator" => "N",
+          "Applicant Unborn Child Indicator" => "Y",
+          "Applicant State Health Benefits CHIP Indicator" => "N",
+          "Applicant CHIP Waiting Period Satisfied Indicator" => "X",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Previously Denied" => "Y"
+        },
+        configs: {
+          # none
+        },
+        expected_outputs: {
+          "Applicant CHIP Indicator" => "N",
+          "CHIP Ineligibility Reason" => 123
+        }
+      },
+      {
+        test_name: "Still passes... because Previously Denied is N",
+        inputs: {
+          "Incarceration Status" => "N",
+          "Applicant CHIP Prelim Indicator" => "N",
+          "Applicant Unborn Child Indicator" => "Y",
+          "Applicant State Health Benefits CHIP Indicator" => "N",
+          "Applicant CHIP Waiting Period Satisfied Indicator" => "X",
+          "Applicant CHIP Targeted Low Income Child Indicator" => "N",
+          "Previously Denied" => "N"
+        },
+        configs: {
+          # none
+        },
+        expected_outputs: {
+          "Applicant CHIP Indicator" => "Y",
+          "CHIP Ineligibility Reason" => 999,
         }
       }
     ]

--- a/test/fixtures/rule_fixtures/medicaid_eligibility.rb
+++ b/test/fixtures/rule_fixtures/medicaid_eligibility.rb
@@ -36,6 +36,36 @@ class MedicaidEligibilityFixture < MagiFixture
         }
       },
       {
+        test_name: "Final Eligibility - Prelim Yes - Previously Denied Y",
+        inputs: {
+          "Applicant Medicaid Prelim Indicator" => "Y",
+          "Previously Denied" => "Y"
+        },
+        configs: {
+          # none
+        },
+        expected_outputs: {
+          "Applicant Medicaid Indicator" => "N",
+          "Medicaid Ineligibility Reason" => 123
+        }
+      },
+      {
+        test_name: "Final Eligibility - Prelim Yes - Previously Denied N",
+        inputs: {
+          "Applicant Medicaid Prelim Indicator" => "Y",
+          "Previously Denied" => "N"
+        },
+        configs: {
+          # none
+        },
+        expected_outputs: {
+          "Applicant Medicaid Indicator" => "Y",
+          "Medicaid Ineligibility Reason" => 999,
+          "APTC Referral Indicator" => "N",
+          "APTC Referral Ineligibility Reason" => 406
+        }
+      },
+      {
         test_name: "Bad Info - Inputs",
         inputs: {
           # none


### PR DESCRIPTION
Requests that exclude Previously Denied should return normally. If `Previously Denied` is present and equal to `Y`, it will override CHIP and Medicaid determinations to `N` and add an extra ineligibility reason.